### PR TITLE
Fix loading total volume from default volumes

### DIFF
--- a/src/sound/sound_manager.rs
+++ b/src/sound/sound_manager.rs
@@ -655,7 +655,7 @@ impl SoundManager {
     /// Write the current slider values into the soundsense-rs/default-volumes.ini file.
     pub fn set_current_volumes_as_default(&self, mut file: File) -> Result<()> {
         use std::io::Write;
-        writeln!(&mut file, "all={}", (self.total_volume.get()*100.0) as u32)?;
+        writeln!(&mut file, "total={}", (self.total_volume.get()*100.0) as u32)?;
         for (channel_name, channel) in self.channels.iter() {
             writeln!(&mut file, "{}={}", channel_name, (channel.get_local_volume()*100.0) as u32)?;
         }


### PR DESCRIPTION
The setting was written with the incorrect name, which caused it not to load at all.

fixes #12 